### PR TITLE
Add CLI summary and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ This repository stores configuration and style data for the **SOPHY Embodied Eve
 
 This repository provides only configuration data. You will need a functioning Evennia installation to use it effectively.
 
+### 🛠️ CLI Utility
+
+A small Python script located at `scripts/summary.py` can print quick summaries of the repository data. Run it with one of the following options:
+
+```bash
+python3 scripts/summary.py server   # show project summary
+python3 scripts/summary.py key      # show Monday's personality summary
+python3 scripts/summary.py styles   # list musical style names
+```
+
 ## 💬 Contributing
 
 Feel free to open issues or pull requests if you have improvements or additional configuration examples to share.

--- a/scripts/summary.py
+++ b/scripts/summary.py
@@ -1,0 +1,54 @@
+import argparse
+import json
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+CFG_DIR = BASE_DIR / "CFG"
+KEY_DIR = BASE_DIR / "KEY"
+RYM_DIR = BASE_DIR / "RYM"
+
+
+def load_json(path: Path):
+    """Load a JSON file and return its data."""
+    with path.open() as f:
+        return json.load(f)
+
+
+def summary_server() -> str:
+    """Return a short summary string for the server configuration."""
+    data = load_json(CFG_DIR / "SERVER.json")
+    return f"{data['PROJECT_NAME']}: {data['DESCRIPTION']}"
+
+
+def summary_key() -> str:
+    """Return a summary of the Monday personality."""
+    data = load_json(KEY_DIR / "MONDAY.JSON")
+    identity = data["neural_imprint"]["identity"]
+    return f"{identity['name']} – {identity['personality']}"
+
+
+def list_styles() -> list[str]:
+    """Return a list of musical style names."""
+    data = load_json(RYM_DIR / "styles.json")
+    return [style['name'] for style in data['styles']]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="SOPHY config summary CLI")
+    parser.add_argument(
+        "section",
+        choices=["server", "key", "styles"],
+        help="Which configuration section to display",
+    )
+    args = parser.parse_args()
+    if args.section == "server":
+        print(summary_server())
+    elif args.section == "key":
+        print(summary_key())
+    elif args.section == "styles":
+        for name in list_styles():
+            print(name)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,0 +1,28 @@
+import unittest
+from pathlib import Path
+
+from scripts.summary import load_json, list_styles, summary_key, summary_server
+
+
+class TestSummary(unittest.TestCase):
+    def test_load_server(self):
+        data = load_json(Path('CFG') / 'SERVER.json')
+        self.assertIn('PROJECT_NAME', data)
+
+    def test_list_styles(self):
+        styles = list_styles()
+        self.assertGreater(len(styles), 0)
+        self.assertIn('anthemic', styles)
+
+    def test_summary_key(self):
+        summary = summary_key()
+        self.assertIn('Monday', summary)
+        self.assertIn('Cynical', summary)
+
+    def test_summary_server(self):
+        summary = summary_server()
+        self.assertIn('SOPHY', summary)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a Python CLI script for summarizing project configuration
- provide unit tests for the new script
- document the CLI utility in the README

## Testing
- `python3 -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_68581b0c0c6c8324b93aab3dfb87c9d6