### PR TITLE
Add config summary script and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ Feel free to open issues or pull requests if you have improvements or additional
 
 These JSON files can be used as a starting point for building or customizing an Evennia installation.  Feel free to modify or extend them for your own needs.
 
+## Configuration Summary Script 🛠️
+
+Run `python config_summary.py` to print a short summary of the configuration files.
+The script displays the project name, Monday's identity, and the number of
+musical styles currently defined.
+
 ## License 📜
 
 This project is released under the [Unlicense](https://unlicense.org/).

--- a/config_summary.py
+++ b/config_summary.py
@@ -1,0 +1,32 @@
+import json
+from pathlib import Path
+
+
+def load_json(path: Path):
+    with path.open() as f:
+        return json.load(f)
+
+
+def get_project_name(cfg_path: Path = Path('CFG') / 'SERVER.json') -> str:
+    return load_json(cfg_path)['PROJECT_NAME']
+
+
+def get_monday_name(key_path: Path = Path('KEY') / 'MONDAY.JSON') -> str:
+    return load_json(key_path)['neural_imprint']['identity']['name']
+
+
+def get_style_count(styles_path: Path = Path('RYM') / 'styles.json') -> int:
+    return len(load_json(styles_path)['styles'])
+
+
+def generate_summary() -> dict:
+    return {
+        'project_name': get_project_name(),
+        'monday_name': get_monday_name(),
+        'style_count': get_style_count(),
+    }
+
+
+if __name__ == '__main__':
+    summary = generate_summary()
+    print(json.dumps(summary, indent=2))

--- a/tests/test_config_summary.py
+++ b/tests/test_config_summary.py
@@ -1,0 +1,13 @@
+import config_summary
+
+
+def test_project_name():
+    assert config_summary.get_project_name() == "SOPHY Embodied Evennia Server"
+
+
+def test_monday_name():
+    assert config_summary.get_monday_name() == "Monday"
+
+
+def test_style_count():
+    assert config_summary.get_style_count() == 23


### PR DESCRIPTION
## Summary
- add a small Python utility that summarizes the JSON config
- document the script in README
- add pytest tests for the helper

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68581b0c0c6c8324b93aab3dfb87c9d6