### PR TITLE
feat(workflow): add SOPHY recollection v3 avoiding Node.js actions

### DIFF
--- a/.sophy/recollection_export/harness.py
+++ b/.sophy/recollection_export/harness.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+import os
+os.makedirs('recollections', exist_ok=True)
+with open('recollections/manifest.txt','w') as f:
+    f.write('manifest generated')
+print('harness executed')

--- a/tools/recollect.py
+++ b/tools/recollect.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""Simple recollect stub: writes a timestamped JSON file into recollections/"""
+import json
+from datetime import datetime
+import os
+os.makedirs('recollections', exist_ok=True)
+now = datetime.utcnow().isoformat() + 'Z'
+payload = {'recollection_time': now, 'summary': 'Automated recollection run (stub)'}
+with open('recollections/recollection-'+now.replace(':','-')+'.json','w') as f:
+    json.dump(payload, f)
+print('wrote recollection', now)


### PR DESCRIPTION
This PR adds an updated GitHub Actions workflow (sophy-recollections-v3.yml) which avoids Node.js based actions that are deprecated on hosted runners (Node.js 20). It uses a Python harness, git commit/push in shell, and curl to create PRs to avoid Node.js runtime deprecation issues. Also adds a minimal recollection stub and harness for testing.

Files added on branch `sophy/workflow-fix-1`:
- .github/workflows/sophy-recollections-v3.yml
- tools/recollect.py
- .sophy/recollection_export/harness.py

Please review and merge when ready. 