### PR TITLE
fix: stabilize BOX workflows by removing PyYAML dependency from recollector

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/tools/recollector/run_recollection.py
+++ b/tools/recollector/run_recollection.py
@@ -1,8 +1,19 @@
 #!/usr/bin/env python3
 import argparse
 import json
-from datetime import datetime
+from datetime import UTC, datetime
 import os
+
+
+def utc_iso_now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def write_simple_yaml(path: str, payload: dict) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        for key, value in payload.items():
+            rendered = str(value).replace("'", "''")
+            f.write(f"{key}: '{rendered}'\n")
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--in', dest='infile', required=True)
@@ -14,7 +25,7 @@ with open(args.infile, 'r') as f:
     threads = json.load(f)
 
 summary = {
-    'generated_at': datetime.utcnow().isoformat() + 'Z',
+    'generated_at': utc_iso_now(),
     'threads_processed': len(threads),
     'threads': threads,
     'summary': 'Auto-generated recollection (dry run: %s)' % args.dry
@@ -25,14 +36,12 @@ with open(os.path.join(args.outdir, 'recollection_summary.json'), 'w') as f:
     json.dump(summary, f, indent=2)
 
 anchor = {
-    'id': 'anchor-' + datetime.utcnow().strftime('%Y%m%d%H%M%S'),
-    'timestamp_utc': datetime.utcnow().isoformat() + 'Z',
+    'id': 'anchor-' + datetime.now(UTC).strftime('%Y%m%d%H%M%S'),
+    'timestamp_utc': utc_iso_now(),
     'root_hash': 'deadbeef',
     'summary': 'Recollection anchor (dry run: %s)' % args.dry,
     'signed_by': 'agent.clockwork'
 }
-with open(os.path.join(args.outdir, 'recollection_anchor.yaml'), 'w') as f:
-    import yaml
-    yaml.dump(anchor, f)
+write_simple_yaml(os.path.join(args.outdir, 'recollection_anchor.yaml'), anchor)
 
 print('Recollection written to', args.outdir)

--- a/tools/recollector/run_recollection_auto.py
+++ b/tools/recollector/run_recollection_auto.py
@@ -1,23 +1,19 @@
 #!/usr/bin/env python3
 import argparse
 import json
-from datetime import datetime
+from datetime import UTC, datetime
 import os
-import sys
-import subprocess
 
-# Ensure PyYAML is available; attempt to install if missing
-try:
-    import yaml
-except Exception:
-    try:
-        print('PyYAML not found; attempting to install...')
-        subprocess.check_call([sys.executable, '-m', 'pip', 'install', '--no-cache-dir', 'PyYAML>=6.0'])
-        import yaml
-        print('PyYAML installed.')
-    except Exception as e:
-        print('Failed to install PyYAML:', e)
-        raise
+
+def utc_iso_now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def write_simple_yaml(path: str, payload: dict) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        for key, value in payload.items():
+            rendered = str(value).replace("'", "''")
+            f.write(f"{key}: '{rendered}'\n")
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--in', dest='infile', required=True)
@@ -29,7 +25,7 @@ with open(args.infile, 'r') as f:
     threads = json.load(f)
 
 summary = {
-    'generated_at': datetime.utcnow().isoformat() + 'Z',
+    'generated_at': utc_iso_now(),
     'threads_processed': len(threads),
     'threads': threads,
     'summary': 'Auto-generated recollection (dry run: %s)' % args.dry
@@ -40,13 +36,12 @@ with open(os.path.join(args.outdir, 'recollection_summary.json'), 'w') as f:
     json.dump(summary, f, indent=2)
 
 anchor = {
-    'id': 'anchor-' + datetime.utcnow().strftime('%Y%m%d%H%M%S'),
-    'timestamp_utc': datetime.utcnow().isoformat() + 'Z',
+    'id': 'anchor-' + datetime.now(UTC).strftime('%Y%m%d%H%M%S'),
+    'timestamp_utc': utc_iso_now(),
     'root_hash': 'deadbeef',
     'summary': 'Recollection anchor (dry run: %s)' % args.dry,
     'signed_by': 'agent.clockwork'
 }
-with open(os.path.join(args.outdir, 'recollection_anchor.yaml'), 'w') as f:
-    yaml.dump(anchor, f)
+write_simple_yaml(os.path.join(args.outdir, 'recollection_anchor.yaml'), anchor)
 
 print('Recollection written to', args.outdir)


### PR DESCRIPTION
### Motivation
- CI and harness runs were failing because `tools/recollector/run_recollection.py` imported `yaml` at runtime on runners without `PyYAML` installed, causing workflow and test collection failures.
- The code used deprecated `datetime.utcnow()` which produced warnings in CI logs and is better expressed with timezone-aware UTC datetimes.

### Description
- Remove the runtime `PyYAML` dependency by adding a small deterministic serializer `write_simple_yaml()` and replacing `yaml.dump(...)` with a local writer in `tools/recollector/run_recollection.py`.
- Make timestamp generation timezone-aware by switching to `datetime.now(UTC)` and a helper `utc_iso_now()` for both `run_recollection.py` and `run_recollection_auto.py` to avoid deprecation warnings.
- Apply the same serializer and timestamp changes to `tools/recollector/run_recollection_auto.py` so both entry points behave consistently.
- Add a `pytest.ini` with `pythonpath = .` so tests can import `config_summary` and `scripts` reliably during collection.

### Testing
- Ran the harness with `bash scripts/run_harness.sh`, which completed successfully and wrote outputs.
- Ran the test suite with `pytest -q`, which passed (8 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0d33987f48324998f5aabd3f17452)