### PR TITLE
Use timezone.utc for recollection timestamps to fix AttributeError

### DIFF
--- a/sophy_hourly_recollection/harness.py
+++ b/sophy_hourly_recollection/harness.py
@@ -58,7 +58,7 @@ def diff_prior(recent, prior):
 
 def run(thread, prior_recollection=None):
     schema = dict(SCHEMA)
-    schema['timestamp'] = datetime.datetime.now(datetime.UTC).isoformat().replace('+00:00', 'Z')
+    schema['timestamp'] = datetime.datetime.now(datetime.timezone.utc).isoformat().replace('+00:00', 'Z')
     schema['thread_id'] = 'local-thread'
     schema['local_digest'] = run_local_digest(thread)
 

--- a/sophy_hourly_recollection/harness_v2.py
+++ b/sophy_hourly_recollection/harness_v2.py
@@ -101,7 +101,7 @@ def write_recollection(schema):
 
 def run(sources, prior_recollection=None):
     schema = dict(SCHEMA_TEMPLATE)
-    schema['timestamp'] = datetime.datetime.now(datetime.UTC).isoformat().replace('+00:00', 'Z')
+    schema['timestamp'] = datetime.datetime.now(datetime.timezone.utc).isoformat().replace('+00:00', 'Z')
     schema['thread_id'] = 'local-thread'
     schema['local_digest'] = run_local_digest(sources)
 

--- a/tools/recollector/run_recollection.py
+++ b/tools/recollector/run_recollection.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 import argparse
 import json
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 import os
 
 
 def utc_iso_now() -> str:
-    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def write_simple_yaml(path: str, payload: dict) -> None:
@@ -36,7 +36,7 @@ with open(os.path.join(args.outdir, 'recollection_summary.json'), 'w') as f:
     json.dump(summary, f, indent=2)
 
 anchor = {
-    'id': 'anchor-' + datetime.now(UTC).strftime('%Y%m%d%H%M%S'),
+    'id': 'anchor-' + datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S'),
     'timestamp_utc': utc_iso_now(),
     'root_hash': 'deadbeef',
     'summary': 'Recollection anchor (dry run: %s)' % args.dry,

--- a/tools/recollector/run_recollection_auto.py
+++ b/tools/recollector/run_recollection_auto.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 import argparse
 import json
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 import os
 
 
 def utc_iso_now() -> str:
-    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def write_simple_yaml(path: str, payload: dict) -> None:
@@ -36,7 +36,7 @@ with open(os.path.join(args.outdir, 'recollection_summary.json'), 'w') as f:
     json.dump(summary, f, indent=2)
 
 anchor = {
-    'id': 'anchor-' + datetime.now(UTC).strftime('%Y%m%d%H%M%S'),
+    'id': 'anchor-' + datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S'),
     'timestamp_utc': utc_iso_now(),
     'root_hash': 'deadbeef',
     'summary': 'Recollection anchor (dry run: %s)' % args.dry,


### PR DESCRIPTION
### Motivation
- CI runs failed with `AttributeError: module 'datetime' has no attribute 'UTC'` because some Python runtimes (e.g., 3.10) do not expose `datetime.UTC`.
- The change switches to the widely supported `datetime.timezone.utc` to ensure deterministic UTC ISO timestamps across runner versions.

### Description
- Replace `datetime.UTC` usage with `datetime.timezone.utc` in `sophy_hourly_recollection/harness.py` and `sophy_hourly_recollection/harness_v2.py` for timestamp generation (preserves `Z` ISO-8601 suffix).
- Update `tools/recollector/run_recollection.py` and `tools/recollector/run_recollection_auto.py` to import `datetime, timezone` and use `timezone.utc` in `utc_iso_now()` and anchor `strftime` generation.
- No schema or output format changes are introduced; only the timezone constant selection was changed for compatibility.

### Testing
- Ran `python3 sophy_hourly_recollection/harness_v2.py` and it completed and wrote a recollection file successfully.
- Executed `from sophy_hourly_recollection.harness import run` and printed the returned timestamp, confirming ISO `Z` output succeeded.
- Compiled the modified files with `python3 -m py_compile` and the check completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c11a81c5c48324867aed877daaf71e)