### PR TITLE
Deterministic recollection: normalize/diff harness, refactor recollect, add tests

### DIFF
--- a/sophy_hourly_recollection/harness.py
+++ b/sophy_hourly_recollection/harness.py
@@ -1,18 +1,15 @@
-"""
-SOPHY Hourly Recollection Harness
+"""SOPHY Hourly Recollection Harness.
 
-This is a deterministic harness template. It runs a local digest over the
-current conversation thread (last 10 turns), attempts cross-thread retrieval
-(30-day window) if connector permissions allow, diffs against prior recollections,
-and emits a strict JSON schema.
-
-Failure code FT-G-01 will be emitted only when neither connector access nor
-local recollection history is available.
+This deterministic harness computes a local digest, attempts to enrich context
+from previous recollection artifacts, and returns a strict schema payload.
 """
+
+from __future__ import annotations
 
 import datetime
 import glob
 import json
+from typing import Any
 
 SCHEMA = {
     "timestamp": None,
@@ -20,25 +17,47 @@ SCHEMA = {
     "local_digest": None,
     "cross_thread_status": "scoped",
     "prior_diff": None,
-    "failure_modes": []
+    "failure_modes": [],
 }
 
 
-def run_local_digest(thread):
-    # placeholder: expects 'thread' as a list of turns
-    return thread[-10:]
+def _normalize_event(event: Any) -> str:
+    """Normalize an event into a single-line string for deterministic diffs."""
+    if isinstance(event, str):
+        return event.strip()
+    if isinstance(event, dict):
+        try:
+            return json.dumps(event, sort_keys=True)
+        except TypeError:
+            return str(event)
+    return str(event)
 
 
-def attempt_cross_thread_retrieval(max_entries=24):
-    files = sorted(glob.glob('recollections/recollection_*.json'), reverse=True)
+def run_local_digest(thread: list[Any], limit: int = 10) -> list[str]:
+    """Return a compact digest from the latest thread items.
+
+    Dev Agent Breadcrumb: Normalize and trim turns so downstream diff logic
+    stays stable even if thread events are mixed types.
+    """
+    normalized = [_normalize_event(event) for event in thread]
+    return [item for item in normalized if item][-limit:]
+
+
+def attempt_cross_thread_retrieval(max_entries: int = 24) -> tuple[dict[str, Any] | None, dict[str, str] | None]:
+    """Load recent recollection files and return latest digest context.
+
+    Dev Agent Breadcrumb: We scan newest-first and stop at the first readable
+    file to keep this call fast and deterministic in CI.
+    """
+    files = sorted(glob.glob("recollections/recollection_*.json"), reverse=True)
     for path in files[:max_entries]:
         try:
-            with open(path, 'r', encoding='utf-8') as handle:
+            with open(path, "r", encoding="utf-8") as handle:
                 data = json.load(handle)
             return {
-                'source': 'local-recollections',
-                'latest_timestamp': data.get('timestamp'),
-                'latest_local_digest': data.get('local_digest', [])
+                "source": "local-recollections",
+                "latest_timestamp": data.get("timestamp") or data.get("recollection_time"),
+                "latest_local_digest": data.get("local_digest", []),
             }, None
         except (OSError, json.JSONDecodeError):
             continue
@@ -47,32 +66,46 @@ def attempt_cross_thread_retrieval(max_entries=24):
         "code": "FT-G-01",
         "title": "limited_execution_context",
         "severity": "actionable",
-        "suggested_mitigation": "Enable cross-thread read permissions or provide exports/manifests for aggregation."
+        "suggested_mitigation": (
+            "Enable cross-thread read permissions or provide exports/manifests "
+            "for aggregation."
+        ),
     }
 
 
-def diff_prior(recent, prior):
-    # naive placeholder diff
-    return {"added": [t for t in recent if t not in (prior or [])], "removed": [t for t in (prior or []) if t not in recent]}
+def diff_prior(recent: list[str], prior: list[str] | None) -> dict[str, list[str]]:
+    """Return deterministic added/removed entries between recent and prior."""
+    prior = prior or []
+
+    # Dev Agent Breadcrumb: set-based membership avoids O(n^2) behavior.
+    prior_set = set(prior)
+    recent_set = set(recent)
+    return {
+        "added": [item for item in recent if item not in prior_set],
+        "removed": [item for item in prior if item not in recent_set],
+    }
 
 
-def run(thread, prior_recollection=None):
+def run(thread: list[Any], prior_recollection: list[str] | None = None) -> dict[str, Any]:
+    """Execute recollection workflow and return the schema payload."""
     schema = dict(SCHEMA)
-    schema['timestamp'] = datetime.datetime.now(datetime.timezone.utc).isoformat().replace('+00:00', 'Z')
-    schema['thread_id'] = 'local-thread'
-    schema['local_digest'] = run_local_digest(thread)
+    schema["timestamp"] = datetime.datetime.now(datetime.timezone.utc).isoformat().replace(
+        "+00:00", "Z"
+    )
+    schema["thread_id"] = "local-thread"
+    schema["local_digest"] = run_local_digest(thread)
 
     cross, err = attempt_cross_thread_retrieval()
     if cross is None:
-        schema['cross_thread_status'] = 'unavailable'
-        schema['failure_modes'].append(err)
+        schema["cross_thread_status"] = "unavailable"
+        schema["failure_modes"].append(err)
     else:
-        schema['cross_thread_status'] = 'available'
-        schema['cross_thread_data'] = cross
+        schema["cross_thread_status"] = "available"
+        schema["cross_thread_data"] = cross
 
     effective_prior = prior_recollection
     if effective_prior is None and cross is not None:
-        effective_prior = cross.get('latest_local_digest', [])
-    schema['prior_diff'] = diff_prior(schema['local_digest'], effective_prior)
+        effective_prior = cross.get("latest_local_digest", [])
+    schema["prior_diff"] = diff_prior(schema["local_digest"], effective_prior)
 
     return schema

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -1,0 +1,43 @@
+import importlib.util
+import json
+from pathlib import Path
+
+HARNESS_PATH = Path(__file__).resolve().parent.parent / "sophy_hourly_recollection" / "harness.py"
+SPEC = importlib.util.spec_from_file_location("harness", HARNESS_PATH)
+harness = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(harness)
+
+
+def test_run_local_digest_normalizes_and_limits():
+    thread = [
+        " a ",
+        {"b": 1, "a": 2},
+        3,
+    ] * 4
+    digest = harness.run_local_digest(thread, limit=3)
+
+    assert len(digest) == 3
+    assert digest[0] == "a"
+    assert digest[1] == '{"a": 2, "b": 1}'
+    assert digest[2] == "3"
+
+
+def test_run_uses_recollection_time_fallback(tmp_path, monkeypatch):
+    recollections = tmp_path / "recollections"
+    recollections.mkdir()
+    seed = {
+        "recollection_time": "2026-03-23T10:00:00Z",
+        "local_digest": ["historic"],
+    }
+    (recollections / "recollection_2026-03-23T10-00-00Z.json").write_text(
+        json.dumps(seed),
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    schema = harness.run(["historic", "new"])
+
+    assert schema["cross_thread_status"] == "available"
+    assert schema["cross_thread_data"]["latest_timestamp"] == "2026-03-23T10:00:00Z"
+    assert schema["prior_diff"]["added"] == ["new"]

--- a/tests/test_recollect.py
+++ b/tests/test_recollect.py
@@ -1,0 +1,18 @@
+import importlib.util
+from pathlib import Path
+
+RECOLLECT_PATH = Path(__file__).resolve().parent.parent / "tools" / "recollect.py"
+SPEC = importlib.util.spec_from_file_location("recollect", RECOLLECT_PATH)
+recollect = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(recollect)
+
+
+def test_write_recollection_creates_file(tmp_path):
+    payload = recollect.build_payload("unit-test")
+
+    out_path = recollect.write_recollection(payload, output_dir=tmp_path)
+
+    assert out_path.exists()
+    assert out_path.parent == tmp_path
+    assert "recollection_" in out_path.name

--- a/tools/recollect.py
+++ b/tools/recollect.py
@@ -1,11 +1,43 @@
 #!/usr/bin/env python3
-"""Simple recollect stub: writes a timestamped JSON file into recollections/"""
+"""Generate a deterministic recollection artifact in ``recollections/``."""
+
+from __future__ import annotations
+
 import json
-from datetime import datetime
-import os
-os.makedirs('recollections', exist_ok=True)
-now = datetime.utcnow().isoformat() + 'Z'
-payload = {'recollection_time': now, 'summary': 'Automated recollection run (stub)'}
-with open('recollections/recollection-'+now.replace(':','-')+'.json','w') as f:
-    json.dump(payload, f)
-print('wrote recollection', now)
+from datetime import datetime, timezone
+from pathlib import Path
+
+OUTPUT_DIR = Path("recollections")
+
+
+def build_payload(summary: str = "Automated recollection run") -> dict[str, str]:
+    """Build a recollection payload using an RFC3339 UTC timestamp."""
+    timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    return {
+        "recollection_time": timestamp,
+        "summary": summary,
+    }
+
+
+def write_recollection(payload: dict[str, str], output_dir: Path = OUTPUT_DIR) -> Path:
+    """Write payload to ``output_dir`` and return created path.
+
+    Dev Agent Breadcrumb: Filename is timestamp-derived to keep generated files
+    sortable and easy to diff in follow-up recollection runs.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    safe_timestamp = payload["recollection_time"].replace(":", "-")
+    out_path = output_dir / f"recollection_{safe_timestamp}.json"
+    out_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return out_path
+
+
+def main() -> None:
+    """CLI entrypoint for local/manual recollection generation."""
+    payload = build_payload()
+    out_path = write_recollection(payload)
+    print(f"wrote recollection {payload['recollection_time']} -> {out_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Remove placeholder/stub logic in the hourly recollection flow to make digesting and cross-thread enrichment deterministic and testable.
- Improve readability and PEP8-style structure and add breadcrumbs to document logic flow for dev agents and auditability.
- Provide small, focused unit tests that validate normalization, history fallbacks, and file write behavior so changes are safe to iterate on.

### Description
- Replaced ad-hoc placeholder code in `sophy_hourly_recollection/harness.py` with typed helpers: `_normalize_event`, `run_local_digest`, `attempt_cross_thread_retrieval`, `diff_prior`, and a clear `run()` entrypoint, and added Dev Agent Breadcrumb comments for logic flow.
- Refactored `tools/recollect.py` into reusable functions `build_payload` and `write_recollection` plus a `main()` CLI, and made file naming deterministic (timestamp-derived) for sortable artifacts.
- Added unit tests `tests/test_harness.py` to verify normalization/limit behavior and recollection-time fallback handling, and `tests/test_recollect.py` to validate recollection file creation.
- Ensured code style via `ruff` and made small API/typing adjustments to keep behavior deterministic across runs.

### Testing
- Ran `ruff check .` and all checks passed.
- Ran `python -m pytest -q` and all unit tests passed (`13 passed`).
- Attempted `python -m pycodestyle .` but the `pycodestyle` package was not installed in the environment, so that check was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c11ce4747c83248f45645b54787cd1)